### PR TITLE
Fix codeready workspaces link

### DIFF
--- a/setup-workshop.sh
+++ b/setup-workshop.sh
@@ -69,7 +69,8 @@ while [[ $(oc get pods --all-namespaces --selector="app=codeready,component=code
    sleep 0.5;
 done
 
-CODEREADY_WORKSPACE_LINK="$(oc get consolelink/workspaces --all-namespaces -o 'jsonpath={..href}')"
+POD_NAMESPACE=$(oc get pods --all-namespaces --selector="app=codeready-operator" -o=jsonpath='{.items[0].metadata.namespace}')
+CODEREADY_WORKSPACE_LINK="$(oc get CheClusters/codeready-workspaces -n ${POD_NAMESPACE} -o 'jsonpath={..cheURL}')"
 printf "\33[2K\r🎉 CodeReady Workspaces available at: %s\n" "${CODEREADY_WORKSPACE_LINK}"
 
 WORKSHOP_WORKSPACE_LINK="${CODEREADY_WORKSPACE_LINK}/f/?url=https://github.com/redhat-developer-demos/quarkus-reactjs-postit-app"


### PR DESCRIPTION
To avoid 

```
⌛️ Waiting on deployment 'codeready' to be ready...Error from server (NotFound): consolelinks.console.openshift.io "workspaces" not found

```